### PR TITLE
Correção - Desafio N3

### DIFF
--- a/DesafioN3-1/ProcessadorDeXml.cs
+++ b/DesafioN3-1/ProcessadorDeXml.cs
@@ -26,11 +26,16 @@ namespace DesafioN3_1
         public decimal SomaTotalXml()
         {
             var total = (decimal)0;
-            Parallel.ForEach(Xmls, (x) =>
+
+            //Parallel.ForEach(Xmls, (x) => //Em testes, retornou um valor total diferente por cada execução.
+            foreach (var x in Xmls)
             {
-                total += decimal.Parse(x.GetElementsByTagName("vNF")[0].InnerXml);
-            });
+                //total += decimal.Parse(x.GetElementsByTagName("vNF")[0].InnerXml);
+                decimal.TryParse(x.GetElementsByTagName("vNF")[0].InnerXml.Replace('.', ','), out decimal valorNF);
+                total += valorNF;
+            };
             return total;
+
         }
 
         public void CarregaXmls(string caminho)


### PR DESCRIPTION
- Implementado uma validação via TryParse para Decimal, para caso algum XML possua tag 'vNF' com valor inválido, não seja interrompido a execução do mesmo.

- Aplicado a conversão de caracter "." para ",", para visualização correta como valor decimal.

- Substituição do Parallel.ForEach, pois em testes realizados, a soma dos valores do XML não era retornada corretamente, exibindo uma valor divergente a cada execução.